### PR TITLE
API Mode Upgrade Fix

### DIFF
--- a/src/bin/xbfwup.c
+++ b/src/bin/xbfwup.c
@@ -392,6 +392,14 @@ main(int argc, char *argv[]) {
 	/* start the power cycle */
 	xb_send_command(xbfd, "FR", "");
 
+	/* 
+	 * In API mode, wait for while before sending in the break
+	 * sequence.  Sending the break immediately causes the XBee
+	 * not to recognize the AT command.
+	 */
+	if (api_mode)
+		usleep(100000);
+
 	/* assert DTR, clear RTS */
 	i = TIOCM_DTR | TIOCM_CTS;
 	ioctl(xbfd, TIOCMSET, &i);


### PR DESCRIPTION
1. Configures serial port before accessing the XBee.
2. Waits for a short time before sending in the break sequence.
